### PR TITLE
Update logic to copy over certificate pinner instance from shared client instance

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -24,6 +24,7 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.network.OkHttpClientProvider;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -235,6 +236,8 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 clientBuilder = RNFetchBlobUtils.getUnsafeOkHttpClient();
             } else {
                 clientBuilder = new OkHttpClient.Builder();
+                // SSL Pinning - Copy over certificate pinner from current client
+                clientBuilder.certificatePinner(OkHttpClientProvider.getOkHttpClient().certificatePinner());
             }
 
             final Request.Builder builder = new Request.Builder();

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobService.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobService.java
@@ -122,6 +122,8 @@ public class RNFetchBlobService extends IntentService implements ProgressListene
         OkHttpClient client = new OkHttpClient.Builder()
                 .writeTimeout(24, TimeUnit.HOURS)
                 .readTimeout(24, TimeUnit.HOURS)
+                // SSL Pinning - Copy over certificate pinner from current client
+                .certificatePinner(OkHttpClientProvider.getOkHttpClient().certificatePinner())
                 .build();
 
         final Call call =  client.newCall(builder.build());


### PR DESCRIPTION
The certificate pinner instance will be reset based on the enable SSL certificate pinning
