### PR TITLE
Attempt to fix crash

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -656,8 +656,15 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
     }
 
     private void emitStateEvent(WritableMap args) {
-        RNFetchBlob.RCTContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit(RNFetchBlobConst.EVENT_HTTP_STATE, args);
+        try {
+            RNFetchBlob.RCTContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit(RNFetchBlobConst.EVENT_HTTP_STATE, args);
+        }
+        catch (Exception ex) {
+            // Fix: Crash, Tried to access a JS module before the React instance was fully set up.
+            //   Calls to ReactContext#getJSModule should only happen once initialize() has been called on your native module.
+            ex.printStackTrace();
+        }
     }
 
     @Override


### PR DESCRIPTION
Symptom:
Crash, Tried to access a JS module before the React instance was fully set up. Calls to ReactContext#getJSModule should only happen once initialize() has been called on your native module.

Workaround:
Add a try-catch block to prevent app crash out
